### PR TITLE
Token Refresh

### DIFF
--- a/src/wyzeapy/wyze_auth_lib.py
+++ b/src/wyzeapy/wyze_auth_lib.py
@@ -102,7 +102,7 @@ class WyzeAuthLib:
         return Token(response_json['access_token'], response_json['refresh_token'])
 
     @property
-    async def should_refresh(self) -> bool:
+    def should_refresh(self) -> bool:
         return time.time() >= self.token.refresh_time
 
     async def refresh_if_should(self):


### PR DESCRIPTION
This change should prevent multiple threads from trying to refresh the token at the same time.

Additionally, there's no reason to refresh the access_token hourly when it's good for 60 hours, so we should be fine refreshing every 48 hours. I don't seem much reason to check that the refresh token is still valid since it is good for ~2 years. At that point... a user should really expect to have to re-login. 

These changes should make it a little easier to store the tokens externally and pass them back to the library so that a re-login is not required each time the library is re-initialized by an application. The token will just need to be passed back in during the create() call.

I did not include comments about it, but the reason that I am re-checking should_refresh inside the asyncio.lock'd code is that if there happens to be a second thread locked in que, I don't think it should bother refreshing the token a second time in such a quick timeframe.