### PR TITLE
Token Refresh

### DIFF
--- a/src/wyzeapy/__init__.py
+++ b/src/wyzeapy/__init__.py
@@ -54,10 +54,6 @@ class Wyzeapy:
         self = cls()
         return self
 
-    async def async_close(self):
-        """This cleans up the async network session"""
-        await self._auth_lib.close()
-
     async def login(self, email, password, token: Token = None):
         """
         Logs the user in and retrieves the users token

--- a/src/wyzeapy/__init__.py
+++ b/src/wyzeapy/__init__.py
@@ -75,6 +75,7 @@ class Wyzeapy:
                 # User token supplied, lets go ahead and use it and refresh the access token if needed.
                 self._auth_lib = await WyzeAuthLib.create(email, password, token, token_callbacks=self.execute_token_callbacks)
                 await self._auth_lib.refresh_if_should()
+                self._service = BaseService(self._auth_lib)
             else:
                 self._auth_lib = await WyzeAuthLib.create(email, password, token_callbacks=self.execute_token_callbacks)
                 await self._auth_lib.get_token_with_username_password(email, password)

--- a/src/wyzeapy/__init__.py
+++ b/src/wyzeapy/__init__.py
@@ -73,11 +73,11 @@ class Wyzeapy:
         try:
             if token:
                 # User token supplied, lets go ahead and use it and refresh the access token if needed.
-                self._auth_lib = await WyzeAuthLib.create(email, password, token, token_callbacks=self.execute_token_callbacks)
+                self._auth_lib = await WyzeAuthLib.create(email, password, token, token_callback=self.execute_token_callbacks)
                 await self._auth_lib.refresh_if_should()
                 self._service = BaseService(self._auth_lib)
             else:
-                self._auth_lib = await WyzeAuthLib.create(email, password, token_callbacks=self.execute_token_callbacks)
+                self._auth_lib = await WyzeAuthLib.create(email, password, token_callback=self.execute_token_callbacks)
                 await self._auth_lib.get_token_with_username_password(email, password)
                 self._service = BaseService(self._auth_lib)
         except TwoFactorAuthenticationEnabled as error:
@@ -110,7 +110,7 @@ class Wyzeapy:
             else:
                 callback(token)
 
-    def register_for_token_callback(self, callback_function: function):
+    def register_for_token_callback(self, callback_function):
         """
         Register a callback to be called whenever the user's token is modified
 
@@ -119,7 +119,7 @@ class Wyzeapy:
         """
         self._token_callbacks.add(callback_function)
 
-    def unregister_for_token_callback(self, callback_function: function):
+    def unregister_for_token_callback(self, callback_function):
         """
         Register a callback to be called whenever the user's token is modified
 

--- a/src/wyzeapy/__init__.py
+++ b/src/wyzeapy/__init__.py
@@ -83,7 +83,7 @@ class Wyzeapy:
         except TwoFactorAuthenticationEnabled as error:
             raise error
 
-    async def login_with_2fa(self, verification_code):
+    async def login_with_2fa(self, verification_code) -> Token:
         """
         Logs the user in and retrieves the users token
 
@@ -95,6 +95,7 @@ class Wyzeapy:
 
         await self._auth_lib.get_token_with_2fa(verification_code)
         self._service = BaseService(self._auth_lib)
+        return self._auth_lib.token
 
     async def execute_token_callbacks(self, token: Token):
         """

--- a/src/wyzeapy/__init__.py
+++ b/src/wyzeapy/__init__.py
@@ -66,9 +66,7 @@ class Wyzeapy:
             TwoFactorAuthenticationEnabled: indicates that the account has 2fa enabled
         """
 
-        _LOGGER.debug(f"Email: {email}")
         self._email = email
-        _LOGGER.debug(f"Password: {password}")
         self._password = password
         try:
             if token:

--- a/src/wyzeapy/__init__.py
+++ b/src/wyzeapy/__init__.py
@@ -5,7 +5,7 @@
 #  joshua@mulliken.net to receive a copy
 import logging
 import time
-from typing import Dict, Any, Optional, Set
+from typing import Dict, Any, List, Optional, Set
 from inspect import iscoroutinefunction
 
 from wyzeapy.const import PHONE_SYSTEM_TYPE, APP_VERSION, SC, APP_VER, SV, PHONE_ID, APP_NAME, OLIVE_APP_ID, APP_INFO
@@ -42,7 +42,7 @@ class Wyzeapy:
         self._email = None
         self._password = None
         self._service: Optional[BaseService] = None
-        self._token_callbacks = {}
+        self._token_callbacks: List[function] = []
 
     @classmethod
     async def create(cls):
@@ -117,7 +117,7 @@ class Wyzeapy:
         :param callback_function: A callback function which expects a token object
 
         """
-        self._token_callbacks.add(callback_function)
+        self._token_callbacks.append(callback_function)
 
     def unregister_for_token_callback(self, callback_function):
         """

--- a/src/wyzeapy/wyze_auth_lib.py
+++ b/src/wyzeapy/wyze_auth_lib.py
@@ -167,11 +167,7 @@ class WyzeAuthLib:
             async with self.refresh_lock:
                 if self.should_refresh:
                     _LOGGER.debug("Should refresh. Refreshing...")
-                    try:
-                        await self.refresh()
-                    except AccessTokenError:
-                        _LOGGER.warning("Could not refresh. Logging in with the Username and Password...")
-                        self.token = await self.get_token_with_username_password(self._username, self._password)
+                    await self.refresh()
 
     async def refresh(self) -> None:
         payload = {

--- a/src/wyzeapy/wyze_auth_lib.py
+++ b/src/wyzeapy/wyze_auth_lib.py
@@ -9,7 +9,7 @@ import time
 from typing import Dict, Any, Optional
 
 import aiohttp
-from aiohttp import TCPConnector, ClientSession
+from aiohttp import TCPConnector, ClientSession, ContentTypeError
 
 from wyzeapy.const import API_KEY, PHONE_ID, APP_NAME, APP_VERSION, SC, SV, PHONE_SYSTEM_TYPE, APP_VER, APP_INFO
 from wyzeapy.exceptions import UnknownApiError, AccessTokenError, TwoFactorAuthenticationEnabled
@@ -214,7 +214,12 @@ class WyzeAuthLib:
             _LOGGER.debug(f"json: {self.sanitize(json)}")
             _LOGGER.debug(f"headers: {self.sanitize(headers)}")
             _LOGGER.debug(f"data: {self.sanitize(data)}")
-            _LOGGER.debug(f"Response: {response}")
+            # Log the response.json() if it exists, if not log the response.
+            try: 
+                response_json = await response.json()
+                _LOGGER.debug(f"Response Json: {response_json}")
+            except ContentTypeError:
+                _LOGGER.debug(f"Response: {response}")
             return await response.json()
 
     async def get(self, url, headers=None, params=None) -> Dict[Any, Any]:

--- a/src/wyzeapy/wyze_auth_lib.py
+++ b/src/wyzeapy/wyze_auth_lib.py
@@ -24,7 +24,7 @@ class Token:
 
     def __init__(self, access_token, refresh_token, refresh_time: float = None):
         self._access_token: str = access_token
-        self.refresh_token: str = refresh_token
+        self._refresh_token: str = refresh_token
         if refresh_time:
             self._refresh_time: float = refresh_time
         else:
@@ -38,6 +38,14 @@ class Token:
     def access_token(self, access_token):
         self._access_token = access_token
         self._refresh_time = time.time() + Token.REFRESH_INTERVAL
+
+    @property
+    def refresh_token(self):
+        return self._refresh_token
+
+    @refresh_token.setter
+    def refresh_token(self, refresh_token):
+        self._refresh_token = refresh_token
 
     @property
     def refresh_time(self):

--- a/src/wyzeapy/wyze_auth_lib.py
+++ b/src/wyzeapy/wyze_auth_lib.py
@@ -22,10 +22,13 @@ class Token:
     # Token is good for 216,000 seconds (60 hours) but 48 hours seems like a reasonable refresh interval
     REFRESH_INTERVAL = 172800
 
-    def __init__(self, access_token, refresh_token):
-        self.access_token: str = access_token
+    def __init__(self, access_token, refresh_token, refresh_time: float = None):
+        self._access_token: str = access_token
         self.refresh_token: str = refresh_token
-        self.refresh_time: float = time.time() + Token.REFRESH_INTERVAL
+        if refresh_time:
+            self._refresh_time: float = refresh_time
+        else:
+            self._refresh_time: float = time.time() + Token.REFRESH_INTERVAL
 
     @property
     def access_token(self):
@@ -35,6 +38,10 @@ class Token:
     def access_token(self, access_token):
         self._access_token = access_token
         self._refresh_time = time.time() + Token.REFRESH_INTERVAL
+
+    @property
+    def refresh_time(self):
+        return self._refresh_time
 
 
 class WyzeAuthLib:


### PR DESCRIPTION
This change should prevent multiple threads from trying to refresh the token at the same time.

Additionally, there's no reason to refresh the token hourly when it's good for 60 hours, so we should be fine refreshing every 48 hours. I don't seem much reason to check that the refresh token is still valid since it is good for ~2 years. At that point... a user should really expect to have to re-login.

These changes should make it a little easier to store the tokens externally and pass them back to the library so that a re-login is not required each time the library is re-initialized by an application. The token will just need to be passed back in during the create() call.