### PR TITLE
wyze_auth_lib: sanitize function - ensure data is a dict

### DIFF
--- a/src/wyzeapy/wyze_auth_lib.py
+++ b/src/wyzeapy/wyze_auth_lib.py
@@ -197,7 +197,7 @@ class WyzeAuthLib:
         await self.token_callback(self.token)
 
     def sanitize(self, data):
-        if data:
+        if data and type(data) is dict:
             # value is unused, but it prevents us from having to split the tuple to check against SANITIZE_FIELDS
             for key, value in data.items():
                 if key in self.SANITIZE_FIELDS:


### PR DESCRIPTION
I had assumed that the data would always be a dict... apparently it is not in some circumstances... so lets just go ahead and make sure that it's a dict before trying to iterate through the dict.