### PR TITLE
228 - Get lock/camera battery statuses

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@
 [metadata]
 # replace with your username:
 name = wyzeapy
-version = 0.3.0b1
+version = 0.3.0b2
 author = Mulliken LLC
 author_email = joshua@mulliken.net
 description = Python client for private Wyze API

--- a/src/wyzeapy/services/base_service.py
+++ b/src/wyzeapy/services/base_service.py
@@ -473,6 +473,7 @@ class BaseService:
 
         payload = {
             "uuid": device_uuid,
+            "with_keypad": "1"
         }
 
         payload = ford_create_payload(self._auth_lib.token.access_token, payload, url_path, "get")

--- a/src/wyzeapy/services/base_service.py
+++ b/src/wyzeapy/services/base_service.py
@@ -103,6 +103,7 @@ class BaseService:
     async def get_updated_params(self, device_mac: str = None) -> Dict[str, Optional[Any]]:
         if time.time() - BaseService._last_updated_time >= BaseService._min_update_time:
             await self.get_object_list()
+            BaseService._last_updated_time = time.time()
         ret_params = {}
         for dev in BaseService._devices:
             if dev.mac == device_mac:

--- a/src/wyzeapy/services/base_service.py
+++ b/src/wyzeapy/services/base_service.py
@@ -464,6 +464,27 @@ class BaseService:
 
         check_for_errors_lock(response_json)
 
+    async def _get_lock_info(self, device: Device) -> Dict[str, Optional[Any]]:
+        await self._auth_lib.refresh_if_should()
+
+        url_path = "/openapi/lock/v1/info"
+
+        device_uuid = device.mac.split(".")[2]
+
+        payload = {
+            "uuid": device_uuid,
+        }
+
+        payload = ford_create_payload(self._auth_lib.token.access_token, payload, url_path, "get")
+
+        url = "https://yd-saas-toc.wyzecam.com/openapi/lock/v1/info"
+
+        response_json = await self._auth_lib.get(url, params=payload)
+
+        check_for_errors_lock(response_json)
+
+        return response_json
+
     async def _get_device_info(self, device: Device) -> Dict[Any, Any]:
         await self._auth_lib.refresh_if_should()
 

--- a/src/wyzeapy/services/bulb_service.py
+++ b/src/wyzeapy/services/bulb_service.py
@@ -59,6 +59,10 @@ class Bulb(Device):
 
 class BulbService(BaseService):
     async def update(self, bulb: Bulb) -> Bulb:
+        # Get updated device_params
+        async with BaseService._update_lock:
+            bulb.device_params = await self.get_updated_params(bulb.mac)
+
         device_info = await self._get_property_list(bulb)
         for property_id, value in device_info:
             if property_id == PropertyIDs.BRIGHTNESS:

--- a/src/wyzeapy/services/camera_service.py
+++ b/src/wyzeapy/services/camera_service.py
@@ -33,6 +33,10 @@ class CameraService(BaseService):
     _subscribers: List[Tuple[Camera, Callable[[Camera], None]]] = []
 
     async def update(self, camera: Camera):
+        # Get updated device_params
+        async with BaseService._update_lock:
+            camera.device_params = await self.get_updated_params(camera.mac)
+
         # Get camera events
         response = await self._get_event_list(10)
         raw_events = response['data']['event_list']

--- a/src/wyzeapy/services/lock_service.py
+++ b/src/wyzeapy/services/lock_service.py
@@ -25,6 +25,9 @@ class LockService(BaseService):
             elif property_id == PropertyIDs.DOOR_OPEN:
                 lock.door_open = value == "1"
 
+        dev_info = await self._get_lock_info(lock)
+        lock.raw_dict = dev_info["device"]
+        
         return lock
 
     async def get_locks(self):

--- a/src/wyzeapy/services/lock_service.py
+++ b/src/wyzeapy/services/lock_service.py
@@ -19,16 +19,16 @@ class LockService(BaseService):
         device_info = await self._get_lock_info(lock)
         lock.raw_dict = device_info["device"]
 
-        lock.available = lock.raw_dict.get("onoff_line") == "1"
-        lock.door_open = lock.raw_dict.get("door_open_status") == "1"
-        lock.trash_mode = lock.raw_dict.get("trash_mode") == "1"
+        lock.available = lock.raw_dict.get("onoff_line") == 1
+        lock.door_open = lock.raw_dict.get("door_open_status") == 1
+        lock.trash_mode = lock.raw_dict.get("trash_mode") == 1
 
         # store the nested dict for easier reference below
         locker_status = lock.raw_dict.get("locker_status")
         # Check if the door is locked
         if locker_status:
             if locker_status.get("door") and locker_status.get("hardlock"):
-                lock.unlocked = locker_status.get("door") == "1" and locker_status.get("hardlock") =="1"
+                lock.unlocked = locker_status.get("door") == 1 and locker_status.get("hardlock") == 1
         
         return lock
 

--- a/src/wyzeapy/services/lock_service.py
+++ b/src/wyzeapy/services/lock_service.py
@@ -14,9 +14,6 @@ class Lock(Device):
 
 class LockService(BaseService):
     async def update(self, lock: Lock):
-        # Get updated device_params
-        async with BaseService._update_lock:
-            lock.device_params = await self.get_updated_params(lock.mac)
 
         device_info = await self._get_property_list(lock)
 

--- a/src/wyzeapy/services/lock_service.py
+++ b/src/wyzeapy/services/lock_service.py
@@ -14,6 +14,10 @@ class Lock(Device):
 
 class LockService(BaseService):
     async def update(self, lock: Lock):
+        # Get updated device_params
+        async with BaseService._update_lock:
+            lock.device_params = await self.get_updated_params(lock.mac)
+
         device_info = await self._get_property_list(lock)
 
         for property_id, value in device_info:

--- a/src/wyzeapy/services/sensor_service.py
+++ b/src/wyzeapy/services/sensor_service.py
@@ -26,6 +26,9 @@ class SensorService(BaseService):
     _subscribers: List[Tuple[Sensor, Callable[[Sensor], None]]] = []
 
     async def update(self, sensor: Sensor) -> Sensor:
+        # Get updated device_params
+        async with BaseService._update_lock:
+            sensor.device_params = await self.get_updated_params(sensor.mac)
         properties = await self._get_device_info(sensor)
 
         for property in properties['data']['property_list']:

--- a/src/wyzeapy/services/switch_service.py
+++ b/src/wyzeapy/services/switch_service.py
@@ -17,6 +17,10 @@ class Switch(Device):
 
 class SwitchService(BaseService):
     async def update(self, switch: Switch):
+        # Get updated device_params
+        async with BaseService._update_lock:
+            switch.device_params = await self.get_updated_params(switch.mac)
+
         device_info = await self._get_property_list(switch)
 
         for property_id, value in device_info:


### PR DESCRIPTION
This change supports the Home Assistant integration [change request](https://github.com/JoshuaMulliken/ha-wyzeapi/issues/228)  to display lock, keypad and Wyze Cam Outdoor batter levels. By cacheing/updating these values we'll also be able to support the request in [Integration Issue #145](https://github.com/JoshuaMulliken/ha-wyzeapi/issues/145)

Basically, we're going to cache the device_params info from the get_device_list endpoint since they hold the battery info. For now, we'll update this info every 20 minutes which should alleviate too much hammering of Wyze's API. That info will provide updated battery levels, ip addresses, RSSIs etc. 

The lock service was modified to reflect these changes and should be fully backward compatible.