### PR TITLE
feat: support camera sirens

### DIFF
--- a/src/wyzeapy/services/camera_service.py
+++ b/src/wyzeapy/services/camera_service.py
@@ -27,6 +27,7 @@ class Camera(Device):
         self.last_event: Optional[Event] = None
         self.last_event_ts: int = int(time.time() * 1000)
         self.on: bool = True
+        self.siren: bool = False
 
 
 class CameraService(BaseService):
@@ -54,6 +55,8 @@ class CameraService(BaseService):
                 camera.available = value == "1"
             if property is PropertyIDs.ON:
                 camera.on = value == "1"
+            if property is PropertyIDs.CAMERA_SIREN:
+                camera.siren = value == "1"
 
         return camera
 
@@ -99,6 +102,12 @@ class CameraService(BaseService):
 
     async def turn_off(self, camera: Camera):
         await self._run_action(camera, "power_off")
+
+    async def siren_on(self, camera: Camera):
+        await self._run_action(camera, "siren_on")
+
+    async def siren_off(self, camera: Camera):
+        await self._run_action(camera, "siren_off")
 
     async def turn_on_notifications(self, camera: Camera):
         plist = [

--- a/src/wyzeapy/types.py
+++ b/src/wyzeapy/types.py
@@ -98,6 +98,7 @@ class PropertyIDs(Enum):
     DOOR_OPEN = "P2001"  # 0 if the door is closed
     CONTACT_STATE = "P1301"
     MOTION_STATE = "P1302"
+    CAMERA_SIREN = "P1049"
 
 
 class ThermostatProps(Enum):


### PR DESCRIPTION
Most of the camera models seem to support the siren feature with the latest firmware. V2, V3 and Wyze Cam Outdoors all support this for sure.

I am fairly confident that P0149 is the correct property id for the siren, but it may need more testing to ensure this is correct for all models.