### PR TITLE
bugfix(wyze_auth_lib): return blank dict for ContentTypeErrors

### DIFF
--- a/src/wyzeapy/wyze_auth_lib.py
+++ b/src/wyzeapy/wyze_auth_lib.py
@@ -233,8 +233,11 @@ class WyzeAuthLib:
                 response_json = await response.json()
                 _LOGGER.debug(f"Response Json: {self.sanitize(response_json)}")
             except ContentTypeError:
+                # lets return a blank dict if we can't parse the response.
+                response_json = []
                 _LOGGER.debug(f"Response: {response}")
-            return await response.json()
+            finally:
+                return response_json
 
     async def get(self, url, headers=None, params=None) -> Dict[Any, Any]:
         async with ClientSession(connector=TCPConnector(ttl_dns_cache=(30 * 60))) as _session:
@@ -249,8 +252,11 @@ class WyzeAuthLib:
                 response_json = await response.json()
                 _LOGGER.debug(f"Response Json: {self.sanitize(response_json)}")
             except ContentTypeError:
+                # lets return a blank dict if we can't parse the response.
+                response_json = []
                 _LOGGER.debug(f"Response: {response}")
-            return await response.json()
+            finally:
+                return response_json
 
     async def patch(self, url, headers=None, params=None, json=None) -> Dict[Any, Any]:
         async with ClientSession(connector=TCPConnector(ttl_dns_cache=(30 * 60))) as _session:
@@ -266,8 +272,11 @@ class WyzeAuthLib:
                 response_json = await response.json()
                 _LOGGER.debug(f"Response Json: {self.sanitize(response_json)}")
             except ContentTypeError:
+                # lets return a blank dict if we can't parse the response.
+                response_json = []
                 _LOGGER.debug(f"Response: {response}")
-            return await response.json()
+            finally:
+                return response_json
 
     async def delete(self, url, headers=None, json=None) -> Dict[Any, Any]:
         async with ClientSession(connector=TCPConnector(ttl_dns_cache=(30 * 60))) as _session:
@@ -282,5 +291,8 @@ class WyzeAuthLib:
                 response_json = await response.json()
                 _LOGGER.debug(f"Response Json: {self.sanitize(response_json)}")
             except ContentTypeError:
+                # lets return a blank dict if we can't parse the response.
+                response_json = []
                 _LOGGER.debug(f"Response: {response}")
-            return await response.json()
+            finally:
+                return response_json


### PR DESCRIPTION
currently, we're not returning anything in the event that we receive a ContentTypeError from aiohttp. This breaks things downstream as they never get a return value from these functions. For now, lets just go ahead and return a blank dictionary so that things don't explode downstream.