### PR TITLE
Remove color mode change

### DIFF
--- a/src/wyzeapy/services/bulb_service.py
+++ b/src/wyzeapy/services/bulb_service.py
@@ -108,9 +108,6 @@ class BulbService(BaseService):
         plist = [
             create_pid_pair(PropertyIDs.ON, "1")
         ]
-        # Put bulb and strip back into basic color mode if it isn't already
-        if bulb.type in [DeviceTypes.LIGHTSTRIP, DeviceTypes.MESH_LIGHT]:
-            plist.append(create_pid_pair(PropertyIDs.COLOR_MODE, "1"))
 
         if options is not None:
             plist.extend(options)


### PR DESCRIPTION
This incorrectly changed color bulbs and strips to color mode with every command. Now handled by ha-wyzeapi.