### PR TITLE
update_manager - Fix: guard against empty que, Fix: typo, refactor: improve logging

### DIFF
--- a/src/wyzeapy/services/update_manager.py
+++ b/src/wyzeapy/services/update_manager.py
@@ -34,6 +34,7 @@ class DeviceUpdater(object):
     async def update(self):
         # We only want to update if the update_in counter is zero
         if self.update_in <= 0:
+            _LOGGER.debug("Updating device: " + self.device.nickname)
             # Acquire the mutex before making the async call
             DeviceUpdater.mutex.acquire()
             try:
@@ -78,6 +79,7 @@ class UpdateManager:
     async def update_next(self):
         # If there are no updaters in the queue we don't need to do anything
         if (len(self.updaters) == 0):
+            _LOGGER.debug("No devices to update in queue")
             return
         while True:
             # First we get the next updater off the queue
@@ -116,10 +118,12 @@ class UpdateManager:
 
     def add_updater(self, updater: DeviceUpdater):
         if len(self.updaters) >= MAX_SLOTS:
+            _LOGGER.exception("No more devices can be updated within the rate limit")
             raise Exception("No more devices can be updated within the rate limit")
 
         # When we add a new updater it has to fit within the max slots or we will not add it
         while (self.filled_slots() + updater.updates_per_interval) > MAX_SLOTS:
+            _LOGGER.debug("Reducing updates per interval to fit new device as slots are full: %s", self.filled_slots())
             # If we are overflowing the available slots we will reduce the frequency of updates evenly for all devices until we can fit in one more.
             self.decrease_updates_per_interval()
             updater.delay()
@@ -129,3 +133,4 @@ class UpdateManager:
 
     def del_updater(self, updater: DeviceUpdater):
         self.removed_updaters.append(updater)
+        _LOGGER.debug("Removing device from update queue")

--- a/src/wyzeapy/services/update_manager.py
+++ b/src/wyzeapy/services/update_manager.py
@@ -42,7 +42,7 @@ class DeviceUpdater(object):
                 # Callback to provide the updated info to the subscriber
                 self.device.callback_function(self.device)
             except:
-                _LOGGER.exception("Unknow error happened during updating device info")
+                _LOGGER.exception("Unknown error happened during updating device info")
             finally:
                 # Release the mutex after the async call
                 DeviceUpdater.mutex.release()

--- a/src/wyzeapy/services/update_manager.py
+++ b/src/wyzeapy/services/update_manager.py
@@ -76,6 +76,9 @@ class UpdateManager:
 
     # This function should be called once every second
     async def update_next(self):
+        # If there are no updaters in the queue we don't need to do anything
+        if (len(self.updaters) == 0):
+            return
         while True:
             # First we get the next updater off the queue
             updater = heappop(self.updaters)


### PR DESCRIPTION
Issue https://github.com/JoshuaMulliken/ha-wyzeapi/issues/452 presented a log where the update_manager would update against an empty queue. While this does not address the main concern in issue 452 of the missing sensors, this empty queue bug needed to be addressed. 

I have also noticed in other reports people have reported "nothing in the logs" because we did not include much (any) logging in this class, so I think it is time that we at least provided some amount of debug logging in this class to provide users with some feedback.

Code is untested, but there is no reason that I can see that it would cause issues.